### PR TITLE
Fix virtualgcc for long PATH values

### DIFF
--- a/virtualgcc/virtualgcc.cpp
+++ b/virtualgcc/virtualgcc.cpp
@@ -503,8 +503,9 @@ bool FindGCC(char *path) {
 }
 
 bool FindGCCPath(char *gcc_bin_path) {
-  char path_value[1024];
-  if (!GetEnvironmentVariable("PATH", path_value, 1024)) {
+  char *path_value;
+  path_value = getenv("PATH");
+  if (!path_value) {
     return false;
   }
 


### PR DESCRIPTION
Previously virtualgcc wouldn't find gcc.exe if the PATH environment variable was longer than 1023 characters.